### PR TITLE
refactor cleantitle.normalize in PTW

### DIFF
--- a/script.module.ptw/lib/ptw/libraries/cleantitle.py
+++ b/script.module.ptw/lib/ptw/libraries/cleantitle.py
@@ -73,14 +73,17 @@ def query(title):
 
 
 maketrans = lambda s1, s2: dict(zip(map(ord, s1), map(ord, s2)))
-unicode_translate_table = maketrans(u'łŁ–—\u2044•„”«»', u'lL--/.""<>')
+unicode_translate_table = maketrans(u'ąćęłńóśźżĄĆĘŁŃÓŚŹŻ–—\u2044•„”«»', u'acelnoszzACELNOSZZ--/.""<>')
 
 def normalize(title):
     """Convert UTF-8 title to ASCII as well as we can."""
     if not isinstance(title, type(u'')):
         title = title.decode('utf-8')
-    title = u''.join(c for c in unicodedata.normalize('NFKD', title)
-                     if unicodedata.category(c) != 'Mn')
+    try:
+        title = u''.join(c for c in unicodedata.normalize('NFKD', title)
+                         if unicodedata.category(c) != 'Mn')
+    except:
+        pass
     return title.translate(unicode_translate_table).encode('ascii', 'replace')
 
 

--- a/script.module.ptw/lib/ptw/libraries/cleantitle.py
+++ b/script.module.ptw/lib/ptw/libraries/cleantitle.py
@@ -72,15 +72,17 @@ def query(title):
     return title
 
 
-def normalize(title):
+maketrans = lambda s1, s2: dict(zip(map(ord, s1), map(ord, s2)))
+unicode_translate_table = maketrans(u'łŁ–—\u2044•„”«»', u'lL--/.""<>')
 
-    try:
-        try: return title.decode('ascii').encode("utf-8")
-        except: pass
-        return str(''.join(c for c in unicodedata.normalize('NFKD', unicode(title.decode('utf-8'))) if unicodedata.category(c) != 'Mn')).replace('ł','l')
-    except:
-        title = str(title).replace('ą','a').replace('ę','e').replace('ć','c').replace('ź','z').replace('ż','z').replace('ó','o').replace('ł','l').replace('ń','n').replace('ś','s')
-        return title
+def normalize(title):
+    """Convert UTF-8 title to ASCII as well as we can."""
+    if not isinstance(title, type(u'')):
+        title = title.decode('utf-8')
+    title = u''.join(c for c in unicodedata.normalize('NFKD', title)
+                     if unicodedata.category(c) != 'Mn')
+    return title.translate(unicode_translate_table).encode('ascii', 'replace')
+
 
 def clean_search_query(url):
     url = url.replace('-','+')


### PR DESCRIPTION
Przeróbka funkcji normalizującej tytuł (UTF-8 → ASCII).
Wstawiam to co napisałem w ramach #40.

Podać można unicode jak i byte-coded string. Zwraca ASCII.
Obsługa małych i dużych liter. Plus kilka innych znaków.
Dzięki czemu mamy konwersję (zawsze można rozszerzyć `unicode_translate_table` jakby co):

UTF-8 | ASCII
--- | ---
Zażółć AŁĆ | Zazolc ALC
• Hit – „Česki Film «Arabela ½»” | . Hit - "Ceski Film <Arabela 1/2>"
µ-film | ?-film

Działa w Python2 i Python3 (choć bytes jest średnio użyteczne).

### Review
Proszę o review i sprawdzenie czy działa poprawnie (testy robiłem ale sobie nie ufam).